### PR TITLE
Fix: case where matplotlib.pyplot is already imported

### DIFF
--- a/pySOT/utils.py
+++ b/pySOT/utils.py
@@ -10,6 +10,7 @@
 
 from pySOT.optimization_problems import OptimizationProblem
 import numpy as np
+import sys
 
 
 def to_unit_box(x, lb, ub):
@@ -166,8 +167,11 @@ def progress_plot(controller, title="", interactive=False):  # pragma: no cover
         import matplotlib.pyplot as plt
         plotting_on = True
     finally:
-        plotting_on = False
-        pass
+        if 'matplotlib.pyplot' not in sys.modules:
+            plotting_on = False
+            pass
+        else:
+            plotting_on = True
 
     if not plotting_on:
         print("Failed to import matplotlib.pyplot, aborting....")


### PR DESCRIPTION
Fixed the utils.progress_plot function that would return  "Failed to import matplotlib.pyplot, aborting...." whenever matplotlib.pyplot is already imported in the user code.