### PR TITLE
Adding back restart functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ sudo: true
 
 language: python
 python:
-  - "3.4"
-  - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   # Install Miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: true
 language: python
 python:
   - "3.6"
-  - "3.7"
 
 install:
   # Install Miniconda

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,18 @@
+v.0.2.3,  2019-07-04
+--------------------
+
+- Adding SOP (Contributed by drkupi)
+- Re-enabling restarts: Start a fresh run when we stop making progress
+
 v.0.2.2,  2019-02-12
 --------------------
+
 - Experimental designs can now map and round to domains
 - Support for generating multiple experimental designs and picking the best
 
 v.0.2.1,  2019-01-26
 --------------------
+
 - Removing numpy.asmatrix calls, since this is now deprecated
 
 v.0.2.0,  2018-12-06

--- a/pySOT/__init__.py
+++ b/pySOT/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 __author__ = 'David Eriksson, David Bindel, Christine Shoemaker'

--- a/pySOT/examples/example_simple.py
+++ b/pySOT/examples/example_simple.py
@@ -23,20 +23,14 @@ def example_simple():
         os.remove("./logfiles/example_simple.log")
     logging.basicConfig(filename="./logfiles/example_simple.log",
                         level=logging.INFO)
-
-    print("\nNumber of threads: 4")
-    print("Maximum number of evaluations: 500")
-    print("Sampling method: CandidateDYCORS")
-    print("Experimental design: Symmetric Latin Hypercube")
-    print("Surrogate: Cubic RBF")
-
+                        
     num_threads = 4
     max_evals = 500
 
     ackley = Ackley(dim=10)
-    rbf = SurrogateUnitBox(RBFInterpolant(dim=ackley.dim, kernel=CubicKernel(),
-                                          tail=LinearTail(ackley.dim)),
-                           lb=ackley.lb, ub=ackley.ub)
+    rbf = SurrogateUnitBox(
+        RBFInterpolant(dim=ackley.dim, kernel=CubicKernel(),
+        tail=LinearTail(ackley.dim)), lb=ackley.lb, ub=ackley.ub)
     slhd = SymmetricLatinHypercube(
         dim=ackley.dim, num_pts=2*(ackley.dim+1))
 

--- a/pySOT/strategy.py
+++ b/pySOT/strategy.py
@@ -239,7 +239,8 @@ class SurrogateBaseStrategy(BaseStrategy):
         if self.num_evals + self.pending_evals >= self.max_evals:  # Budget exhausted
             self.terminate = True
 
-    def sample_restart(self):
+    def sample_restart(self):Thank you for making changes to the paper! I’m currently at ICML and will take a couple of days of vacation right after, so I won’t be back at my desk for another 10 days or so. I should have plenty of time to work on this once I’m back, so please remind me if you haven’t heard from me by the end of June.
+
         """Restart a run after convergence."""
         self.ev_restart = self.ev_next
         self.ev_next += 1
@@ -544,8 +545,8 @@ class SRBFStrategy(SurrogateBaseStrategy):
     """
     def __init__(self, max_evals, opt_prob, exp_design, surrogate,
                  asynchronous=True, batch_size=None, extra_points=None,
-                 extra_vals=None, reset_surrogate=True, weights=None,
-                 num_cand=None):
+                 extra_vals=None, reset_surrogate=True, use_restarts=True, 
+                 weights=None, num_cand=None):
 
         self.fbest = np.inf  # Current best function value
 
@@ -581,7 +582,7 @@ class SRBFStrategy(SurrogateBaseStrategy):
                          exp_design=exp_design, surrogate=surrogate,
                          asynchronous=asynchronous, batch_size=batch_size,
                          extra_points=extra_points, extra_vals=extra_vals,
-                         reset_surrogate=reset_surrogate)
+                         reset_surrogate=reset_surrogate, use_restarts=use_restarts)
 
     def check_input(self):
         """Check inputs."""
@@ -648,10 +649,10 @@ class SRBFStrategy(SurrogateBaseStrategy):
                                         self.sampling_radius_max])
             logger.info("Increasing sampling radius")
 
-        # Check if we want to terminate
+        # Check if we have converged
         if self.failcount >= self.maxfailtol or \
                 self.sampling_radius <= self.sampling_radius_min:
-            self.terminate = True
+            self.converged = True
 
         # Empty the queue
         self.record_queue = []
@@ -699,7 +700,7 @@ class DYCORSStrategy(SRBFStrategy):
     """
     def __init__(self, max_evals, opt_prob, exp_design, surrogate,
                  asynchronous=True, batch_size=None, extra_points=None,
-                 extra_vals=None, weights=None, num_cand=None):
+                 extra_vals=None, use_restarts=True, weights=None, num_cand=None):
 
         self.num_exp = exp_design.num_pts  # We need this later
 
@@ -707,7 +708,7 @@ class DYCORSStrategy(SRBFStrategy):
                          exp_design=exp_design, surrogate=surrogate,
                          asynchronous=asynchronous, batch_size=batch_size,
                          extra_points=extra_points, extra_vals=extra_vals,
-                         weights=weights, num_cand=num_cand)
+                         weights=weights, num_cand=num_cand, use_restarts=use_restarts)
 
     def generate_evals(self, num_pts):
         """Generate the next adaptive sample points."""
@@ -783,7 +784,8 @@ class EIStrategy(SurrogateBaseStrategy):
     def __init__(self, max_evals, opt_prob, exp_design,
                  surrogate, asynchronous=True, batch_size=None,
                  extra_points=None, extra_vals=None,
-                 reset_surrogate=True, ei_tol=None, dtol=None):
+                 reset_surrogate=True, use_restarts=True, 
+                 ei_tol=None, dtol=None):
 
         if dtol is None:
             dtol = 1e-3 * np.linalg.norm(opt_prob.ub - opt_prob.lb)
@@ -811,7 +813,7 @@ class EIStrategy(SurrogateBaseStrategy):
             ei_tol=ei_tol)
 
         if new_points is None:  # Not enough improvement
-            self.terminate = True
+            self.convereged = True
         else:
             for i in range(num_pts):
                 self.batch_queue.append(np.copy(np.ravel(new_points[i, :])))
@@ -870,8 +872,8 @@ class LCBStrategy(SurrogateBaseStrategy):
     def __init__(self, max_evals, opt_prob, exp_design,
                  surrogate, asynchronous=True, batch_size=None,
                  extra_points=None, extra_vals=None,
-                 reset_surrogate=True, kappa=2.0, dtol=None,
-                 lcb_tol=None):
+                 reset_surrogate=True, use_restarts=True, 
+                 kappa=2.0, dtol=None, lcb_tol=None):
 
         if dtol is None:
             dtol = 1e-3 * np.linalg.norm(opt_prob.ub - opt_prob.lb)
@@ -901,7 +903,7 @@ class LCBStrategy(SurrogateBaseStrategy):
             dtol=self.dtol, lcb_target=lcb_target)
 
         if new_points is None:  # Not enough improvement
-            self.terminate = True
+            self.converged = True
         else:
             for i in range(num_pts):
                 self.batch_queue.append(np.copy(np.ravel(new_points[i, :])))

--- a/pySOT/strategy.py
+++ b/pySOT/strategy.py
@@ -453,11 +453,14 @@ class SurrogateBaseStrategy(BaseStrategy):
 
         xx, fx = np.copy(record.params[0]), record.value
         self.X = np.vstack((self.X, np.atleast_2d(xx)))
-        self._X = np.vstack((self._X, np.atleast_2d(xx)))
         self.fX = np.vstack((self.fX, fx))
-        self._fX = np.vstack((self._fX, fx))
-        self.surrogate.add_points(xx, fx)
         self.remove_pending(xx)
+
+        # Only count point if it was proposed after the last restart
+        if record.ev_id > self.ev_restart:
+            self._X = np.vstack((self._X, np.atleast_2d(xx)))
+            self._fX = np.vstack((self._fX, fx))
+            self.surrogate.add_points(xx, fx)
 
         self.log_completion(record)
         self.fevals.append(record)

--- a/pySOT/strategy.py
+++ b/pySOT/strategy.py
@@ -320,7 +320,7 @@ class SurrogateBaseStrategy(BaseStrategy):
                     self.sample_restart() # Trigger the restart
                     return self.init_proposal()  # We are now in phase 1, so make an initial proposal
                 else:
-                    return  
+                    return
         elif self.batch_queue:  # Propose point from the batch_queue
             if self.phase == 1:
                 return self.init_proposal()
@@ -340,10 +340,10 @@ class SurrogateBaseStrategy(BaseStrategy):
                         self.sample_restart() # Trigger the restart
                         return self.init_proposal()  # We are now in phase 1, so make an initial proposal
                     else:
-                        return  
+                        return
 
             # Launch the new evaluations (the others will be triggered later)
-            return self.adapt_proposal()        
+            return self.adapt_proposal()
 
     def make_proposal(self, x):
         """Create proposal and update counters and budgets."""
@@ -559,10 +559,8 @@ class SRBFStrategy(SurrogateBaseStrategy):
     """
     def __init__(self, max_evals, opt_prob, exp_design, surrogate,
                  asynchronous=True, batch_size=None, extra_points=None,
-                 extra_vals=None, use_restarts=True, 
+                 extra_vals=None, use_restarts=True,
                  weights=None, num_cand=None):
-
-        self.fbest = np.inf  # Current best function value
 
         self.dtol = 1e-3 * math.sqrt(opt_prob.dim)
         if weights is None:
@@ -603,11 +601,11 @@ class SRBFStrategy(SurrogateBaseStrategy):
         super().check_input()
 
     def sample_initial(self):
+        super().sample_initial()
         self.status = 0          # Status counter
         self.failcount = 0       # Failure counter
         self.sampling_radius = 0.2
-
-        super().sample_initial()
+        self._fbest = np.inf  # Current best function value
 
     def on_adapt_completed(self, record):
         """Handle completed evaluation."""
@@ -634,7 +632,7 @@ class SRBFStrategy(SurrogateBaseStrategy):
         weights = self.get_weights(num_pts=num_pts)
         new_points = candidate_srbf(
             opt_prob=self.opt_prob, num_pts=num_pts, surrogate=self.surrogate,
-            X=self.X, fX=self.fX, Xpend=self.Xpend, weights=weights,
+            X=self._X, fX=self._fX, Xpend=self.Xpend, weights=weights,
             sampling_radius=self.sampling_radius, num_cand=self.num_cand)
 
         for i in range(num_pts):
@@ -648,9 +646,8 @@ class SRBFStrategy(SurrogateBaseStrategy):
         """
         # Check if we succeeded at significant improvement
         fbest_new = min([record.value for record in self.record_queue])
-        if fbest_new < self.fbest - 1e-3*math.fabs(self.fbest) or \
-                np.isinf(self.fbest):  # Improvement
-            self.fbest = fbest_new
+        if fbest_new < self._fbest - 1e-3*math.fabs(self._fbest) or np.isinf(self._fbest):  # Improvement
+            self._fbest = fbest_new
             self.status = max(1, self.status + 1)
             self.failcount = 0
         else:
@@ -727,7 +724,7 @@ class DYCORSStrategy(SRBFStrategy):
                          exp_design=exp_design, surrogate=surrogate,
                          asynchronous=asynchronous, batch_size=batch_size,
                          extra_points=extra_points, extra_vals=extra_vals,
-                         use_restarts=use_restarts,  weights=weights, 
+                         use_restarts=use_restarts,  weights=weights,
                          num_cand=num_cand)
 
     def generate_evals(self, num_pts):
@@ -743,7 +740,7 @@ class DYCORSStrategy(SRBFStrategy):
         weights = self.get_weights(num_pts=num_pts)
         new_points = candidate_dycors(
             opt_prob=self.opt_prob, num_pts=num_pts, surrogate=self.surrogate,
-            X=self.X, fX=self.fX, Xpend=self.Xpend, weights=weights,
+            X=self._X, fX=self._fX, Xpend=self.Xpend, weights=weights,
             num_cand=self.num_cand, sampling_radius=self.sampling_radius,
             prob_perturb=prob_perturb)
 
@@ -831,7 +828,7 @@ class EIStrategy(SurrogateBaseStrategy):
 
         new_points = expected_improvement_ga(
             num_pts=num_pts, opt_prob=self.opt_prob, surrogate=self.surrogate,
-            X=self.X, fX=self.fX, Xpend=self.Xpend, dtol=self.dtol,
+            X=self._X, fX=self._fX, Xpend=self.Xpend, dtol=self.dtol,
             ei_tol=ei_tol)
 
         if new_points is None:  # Not enough improvement
@@ -921,7 +918,7 @@ class LCBStrategy(SurrogateBaseStrategy):
 
         new_points = lower_confidence_bound_ga(
             num_pts=num_pts, opt_prob=self.opt_prob, surrogate=self.surrogate,
-            X=self.X, fX=self.fX, Xpend=self.Xpend, kappa=self.kappa,
+            X=self._X, fX=self._fX, Xpend=self.Xpend, kappa=self.kappa,
             dtol=self.dtol, lcb_target=lcb_target)
 
         if new_points is None:  # Not enough improvement
@@ -1103,7 +1100,6 @@ class SOPStrategy(SurrogateBaseStrategy):
                  asynchronous=True, batch_size=None, extra_points=None,
                  extra_vals=None, use_restarts=True, num_cand=None):
 
-        self.fbest = np.inf  # Current best function value
         self.dtol = 1e-3 * math.sqrt(opt_prob.dim)
 
         if num_cand is None:
@@ -1203,8 +1199,8 @@ class SOPStrategy(SurrogateBaseStrategy):
                 self.evals[self.centers[center_index].index].sigma
             new_points[i, :] =\
                 candidate_dycors(num_pts=1, opt_prob=self.opt_prob,
-                                 surrogate=self.surrogate, X=self.X,
-                                 fX=self.fX, weights=weights,
+                                 surrogate=self.surrogate, X=self._X,
+                                 fX=self._fX, weights=weights,
                                  sampling_radius=sampling_radius,
                                  num_cand=self.num_cand, Xpend=self.Xpend,
                                  prob_perturb=prob_perturb, xbest=X_c)

--- a/pySOT/strategy.py
+++ b/pySOT/strategy.py
@@ -835,7 +835,7 @@ class EIStrategy(SurrogateBaseStrategy):
             ei_tol=ei_tol)
 
         if new_points is None:  # Not enough improvement
-            self.convereged = True
+            self.converged = True
         else:
             for i in range(num_pts):
                 self.batch_queue.append(np.copy(np.ravel(new_points[i, :])))

--- a/pySOT/tests/test_controller.py
+++ b/pySOT/tests/test_controller.py
@@ -22,21 +22,13 @@ def check_strategy(controller):
     """Make sure the strategy object is correct."""
 
     # Check the strategy object
-    assert controller.strategy.num_evals <= controller.strategy.max_evals
-    assert controller.strategy.phase == 2
-    assert controller.strategy.init_pending == 0
+    assert controller.strategy.num_evals == controller.strategy.max_evals
     assert controller.strategy.pending_evals == 0
     assert controller.strategy.X.shape == \
         (controller.strategy.num_evals, ackley.dim)
     assert controller.strategy.fX.shape == (controller.strategy.num_evals, 1)
     assert controller.strategy.Xpend.shape == (0, ackley.dim)
     assert len(controller.strategy.fevals) == controller.strategy.num_evals
-
-    # Check that all evaluations are in the surrogate model
-    assert controller.strategy.surrogate.num_pts == \
-        controller.strategy.num_evals
-    assert np.all(controller.strategy.X == controller.strategy.surrogate.X)
-    assert np.all(controller.strategy.fX == controller.strategy.surrogate.fX)
 
     # Check that the strategy and controller have the same information
     assert len(controller.fevals) == controller.strategy.num_evals

--- a/pySOT/tests/test_strategies.py
+++ b/pySOT/tests/test_strategies.py
@@ -17,8 +17,7 @@ def check_strategy(controller):
     """Make sure the strategy object is correct."""
 
     # Check the strategy object
-    assert controller.strategy.num_evals <= controller.strategy.max_evals
-    assert controller.strategy.phase == 2
+    assert controller.strategy.num_evals == controller.strategy.max_evals
     assert controller.strategy.init_pending == 0
     assert controller.strategy.pending_evals == 0
     assert controller.strategy.X.shape == \
@@ -26,12 +25,6 @@ def check_strategy(controller):
     assert controller.strategy.fX.shape == (controller.strategy.num_evals, 1)
     assert controller.strategy.Xpend.shape == (0, ackley.dim)
     assert len(controller.strategy.fevals) == controller.strategy.num_evals
-
-    # Check that all evaluations are in the surrogate model
-    assert controller.strategy.surrogate.num_pts == \
-        controller.strategy.num_evals
-    assert np.all(controller.strategy.X == controller.strategy.surrogate.X)
-    assert np.all(controller.strategy.fX == controller.strategy.surrogate.fX)
 
     # Check that the strategy and controller have the same information
     for i in range(controller.strategy.num_evals):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ long_description = open('README.rst').read()
 
 setup(
     name='pySOT',
-    version='0.2.2',
+    version='0.2.3',
     packages=['pySOT', 'pySOT.examples', 'pySOT.tests'],
     url='https://github.com/dme65/pySOT',
     license='LICENSE.rst',


### PR DESCRIPTION
Adding an argument ```use_restarts```(default ```True```) to the optimization strategies. This starts a  fresh optimization run if the budget is not exhausted and the optimization run has stopped making progress. We don't terminate pending evaluations when we restart, but we don't incorporate them into the surrogate model when they are completed.