### PR TITLE
Fix cholesky exception handling in rbf

### DIFF
--- a/pySOT/surrogate/rbf.py
+++ b/pySOT/surrogate/rbf.py
@@ -148,7 +148,7 @@ class RBFInterpolant(Surrogate):
                 L21 = L21.T
                 try:  # Compute Cholesky factorization of the Schur complement
                     C = scplinalg.cholesky(a=Phinew - np.dot(L21, U12), lower=True)
-                finally:  # Compute a new LU factorization if Cholesky fails
+                except:  # Compute a new LU factorization if Cholesky fails
                     self.c = None
                     return self._fit()
 


### PR DESCRIPTION
Hi! While reading the rbf.py, I noticed a typo in the exception handling of Cholesky factorization of the Schur complement, where the syntax "finally" should be corrected as "except". Due to such a typo, the proposed speed-up model update method doesn't work during algorithm iterations.